### PR TITLE
Fix module definition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tree-sitter-debugger
+module github.com/meain/tree-sitter-debugger
 
 go 1.21
 


### PR DESCRIPTION
Hello! I came here from your blog post —esa looks awesome, I have to try it!— but I was unable to follow the installation instructions:

```bash
╭─ ~/Repositorios/tree-sitter-debugger  master ?1 ······························································································································································································ 08:49:05 
╰─❯ go install github.com/meain/tree-sitter-debugger@latest
go: github.com/meain/tree-sitter-debugger@latest: version constraints conflict:
        github.com/meain/tree-sitter-debugger@v0.0.0-20250629143703-93711e5755e6: parsing go.mod:
        module declares its path as: tree-sitter-debugger
                but was required as: github.com/meain/tree-sitter-debugger
```

This should fix it ˆˆ